### PR TITLE
Add SDC suppression and rounding to patients by geography df

### DIFF
--- a/data-raw/patients_by_geography_and_gender_and_age_band_df.R
+++ b/data-raw/patients_by_geography_and_gender_and_age_band_df.R
@@ -135,6 +135,21 @@ patients_by_geography_and_gender_and_age_band_df <-
   collect() %>%
   careHomePrescribingScrollytellR::format_data_raw(GENDER, AGE_BAND)
 
+# Statistical Disclosure Control to suppress low numbers and round to nearest 10
+patients_by_geography_and_gender_and_age_band_df <- patients_by_geography_and_gender_and_age_band_df %>%
+  mutate(TOTAL_PATIENTS = case_when(
+    TOTAL_PATIENTS == 0 ~ 0,
+    TOTAL_PATIENTS > 0 & TOTAL_PATIENTS <= 4 ~ NA_real_,
+    TOTAL_PATIENTS >= 5 & TOTAL_PATIENTS <= 9 ~ 10,
+    TRUE ~ as.numeric(plyr::round_any(TOTAL_PATIENTS, 10))
+  )
+  )
+
+# Replace suppressed NA value with C
+patients_by_geography_and_gender_and_age_band_df$TOTAL_PATIENTS <- ifelse(
+  is.na(patients_by_geography_and_gender_and_age_band_df$TOTAL_PATIENTS), "c", 
+  patients_by_geography_and_gender_and_age_band_df$TOTAL_PATIENTS)
+
 # Add to data-raw/
 usethis::use_data(
   patients_by_geography_and_gender_and_age_band_df,


### PR DESCRIPTION
Closes #87 

Applied logic to suppress and round values for SDC to TOTAL_PATIENTS within the `patients_by_geography_and_gender_and_age_band_df.R` file. 

Logic applied is as below, with all values to be rounded to the nearest 10.

<html>
<body>
<!--StartFragment-->

Current value | Proposed value
-- | --
0 | 0
1 - 4 | NA
5-9 | 10

<!--EndFragment-->
</body>
</html>

Once this step has been applied, further logic replaces all `NA` values with `c`, which is common practice within Official Stats